### PR TITLE
fix onnx model path

### DIFF
--- a/main.py
+++ b/main.py
@@ -127,8 +127,7 @@ def main():
     ### ONNX Setup ###
     model_params = BrainFlowModelParams(BrainFlowMetrics.USER_DEFINED.value,
                                         BrainFlowClassifiers.ONNX_CLASSIFIER.value)
-    model_params.file = os.path.join(
-        os.getcwd(), 'ml-spotify', 'spotify_emotion.onnx')
+    model_params.file = os.path.join(os.getcwd(), 'spotify_emotion.onnx')
     model = MLModel(model_params)
     model.prepare()
 

--- a/train.py
+++ b/train.py
@@ -84,6 +84,9 @@ loss_function = nn.MSELoss()
 optimizer = optim.Adam(model.parameters(), lr=0.001)
 loss_list = []
 
+test_batches = list(test_batches)
+target_var = np.var([list(zip(*test_batch))[0][0] for test_batch in test_batches])
+
 for i, test_batch in enumerate(test_batches):
 
     # get batch and format for pytorch
@@ -101,11 +104,11 @@ for i, test_batch in enumerate(test_batches):
     loss.backward()
     optimizer.step()
 
-    print(i, batches_count, loss.item(), target_emotions[0], outputs[0])
+    print(i, batches_count, loss.item() / target_var, target_emotions[0], outputs[0])
     loss_list.append(loss.item())
 
-    if loss.item() < 0.05:
-        break
+    #if loss.item() < 0.05:
+    #    break
 
 # Save as ONNX model
 dummy_input = inputs[0]


### PR DESCRIPTION
```
(museenv) C02TX318HV2R:BrainEmotionToVRChat einanao$ python main.py --board-id 21 --serial-port /dev/cu.usbmodem11
[2022-07-28 22:50:06.747] [board_logger] [error] [json.exception.type_error.302] type must be number, but is null
[2022-07-28 22:50:06.747] [board_logger] [info] incoming json: {
    "file": "",
    "ip_address": "",
    "ip_port": 0,
    "ip_protocol": 0,
    "mac_address": "",
    "other_info": "",
    "serial_number": "",
    "serial_port": "/dev/cu.usbmodem11",
    "timeout": 0
}
[2022-07-28 22:50:10.541] [ml_logger] [error] CreateSession failed: Load model from /Users/einanao/BrainEmotionToVRChat/ml-spotify/spotify_emotion.onnx failed:Load model /Users/einanao/BrainEmotionToVRChat/ml-spotify/spotify_emotion.onnx failed. File doesn't exist
[2022-07-28 22:50:10.541] [ml_logger] [error] Unable to prepare model. Please refer to logs above.
Traceback (most recent call last):
  File "main.py", line 201, in <module>
    main()
  File "main.py", line 133, in main
    model.prepare()
  File "/Users/einanao/opt/miniconda3/envs/museenv/lib/python3.8/site-packages/brainflow/ml_model.py", line 252, in prepare
    raise BrainFlowError('unable to prepare classifier', res)
brainflow.exit_codes.BrainFlowError: GENERAL_ERROR:17 unable to prepare classifier
```